### PR TITLE
Code cleanup of onlyIf class method

### DIFF
--- a/src/observable.ts
+++ b/src/observable.ts
@@ -36,10 +36,8 @@ export class Observable<T> {
 		return this.transform(val => {
 			if (predicate(val)) {
 				prevVal = val;
-				return val;
-			} else {
-				return prevVal;
-			}
+			} 
+			return prevVal;
 		});
 	}
 


### PR DESCRIPTION
Saves a little space by removing an unnecessary return and else{} block